### PR TITLE
feat: improve eval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "discord.js": "^13.5.1",
         "dotenv": "^10.0.0",
         "express": "^4.17.2",
+        "prettier": "^2.5.1",
         "tsup": "^5.11.11",
         "typescript": "^4.5.4",
         "utf-8-validate": "^5.0.8",
@@ -25,13 +26,13 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
+        "@types/prettier": "^2.4.3",
         "@typescript-eslint/eslint-plugin": "^5.9.0",
         "@typescript-eslint/parser": "^5.9.0",
         "eslint": "^8.6.0",
         "eslint-plugin-node": "^11.1.0",
         "husky": "^7.0.0",
-        "node": "^16.13.1",
-        "prettier": "^2.5.1"
+        "node": "^16.13.1"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -279,6 +280,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/prettier": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.3.tgz",
+      "integrity": "sha512-QzSuZMBuG5u8HqYz01qtMdg/Jfctlnvj1z/lYnIDXs/golxw0fxtRAHd9KrzjR7Yxz1qVeI00o0kiO3PmVdJ9w==",
+      "dev": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -2530,7 +2537,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
       "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
-      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -3500,6 +3506,12 @@
           }
         }
       }
+    },
+    "@types/prettier": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.3.tgz",
+      "integrity": "sha512-QzSuZMBuG5u8HqYz01qtMdg/Jfctlnvj1z/lYnIDXs/golxw0fxtRAHd9KrzjR7Yxz1qVeI00o0kiO3PmVdJ9w==",
+      "dev": true
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -5083,8 +5095,7 @@
     "prettier": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
-      "dev": true
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg=="
     },
     "progress": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "keywords": [
     "utility-bot"
   ],
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "author": "NotReallyEight",
   "license": "MIT",
   "bugs": {
@@ -34,6 +37,7 @@
     "discord.js": "^13.5.1",
     "dotenv": "^10.0.0",
     "express": "^4.17.2",
+    "prettier": "^2.5.1",
     "tsup": "^5.11.11",
     "typescript": "^4.5.4",
     "utf-8-validate": "^5.0.8",
@@ -41,12 +45,12 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
+    "@types/prettier": "^2.4.3",
     "@typescript-eslint/eslint-plugin": "^5.9.0",
     "@typescript-eslint/parser": "^5.9.0",
     "eslint": "^8.6.0",
     "eslint-plugin-node": "^11.1.0",
     "husky": "^7.0.0",
-    "node": "^16.13.1",
-    "prettier": "^2.5.1"
+    "node": "^16.13.1"
   }
 }

--- a/src/commands/text/eval.ts
+++ b/src/commands/text/eval.ts
@@ -1,95 +1,77 @@
-import { Command } from "../../utils/Command";
 import util from "node:util";
-import { Logger } from "../../utils/Logger";
+import prettier from "prettier";
 import { config } from "../../config";
+import { Command } from "../../utils/Command";
+import { Logger } from "../../utils/Logger";
+
+/**
+ * Inspect an eval result.
+ * @param value - The value to inspect
+ * @returns A string representation of the value
+ */
+const inspect = (value: unknown) => {
+	switch (typeof value) {
+		case "string":
+			return value;
+		case "bigint":
+		case "number":
+		case "boolean":
+		case "function":
+		case "symbol":
+			return value.toString();
+		case "object":
+			return util.inspect(value);
+		default:
+			return "undefined";
+	}
+};
 
 export const command = new Command(
 	"eval",
 	async (message, args, _client) => {
 		try {
-			const text = args.join(" ");
+			let result,
+				text = args.join(" "),
+				typeOfResult;
 
-			let result: string = (await eval(text)) as string;
-			const typeOfResult = typeof result;
-			if (typeOfResult === "object") {
-				result = util.inspect(result);
-				await message.channel.send({
-					embeds: [
-						{
-							title: "Eval",
-							color: config.commandsEmbedsColor,
-							fields: [
-								{
-									name: "Eval Input",
-									value: `\`\`\`js\n${text.slice(0, 1008)}\`\`\``,
-									inline: false,
-								},
-								{
-									name: "Eval Output",
-									value: `\`\`\`js\n${result.toString().slice(0, 1008)}\`\`\``,
-									inline: false,
-								},
-								{
-									name: "Eval Type",
-									value: `\`\`\`js\n${typeOfResult}\`\`\``,
-									inline: false,
-								},
-							],
-						},
-					],
-				});
-			} else if (typeof result === "undefined")
-				await message.channel.send({
-					embeds: [
-						{
-							title: "Eval",
-							color: config.commandsEmbedsColor,
-							fields: [
-								{
-									name: "Eval Input",
-									value: `\`\`\`js\n${text.slice(0, 1008)}\`\`\``,
-									inline: false,
-								},
-								{
-									name: "Eval Output",
-									value: `\`\`\`js\nundefined\`\`\``,
-									inline: false,
-								},
-								{
-									name: "Eval Type",
-									value: `\`\`\`js\n${typeOfResult}\`\`\``,
-									inline: false,
-								},
-							],
-						},
-					],
-				});
-			else
-				await message.channel.send({
-					embeds: [
-						{
-							title: "Eval",
-							color: 0xbeeccd,
-							fields: [
-								{
-									name: "Eval Input",
-									value: `\`\`\`js\n${text.slice(0, 1008)}\`\`\``,
-									inline: false,
-								},
-								{
-									name: "Eval Output",
-									value: `\`\`\`js\n${result.toString().slice(0, 1008)}\`\`\``,
-									inline: false,
-								},
-								{
-									name: "Eval Type",
-									value: `\`\`\`js\n${typeOfResult}\`\`\``,
-									inline: false,
-								},
-							],
-						},
-					],
-				});
+			try {
+				text = prettier
+					.format(text, {
+						...((await prettier
+							.resolveConfig(".prettierrc.json")
+							.catch(() => null)) ?? {}),
+					})
+					.slice(0, -1);
+				result = (await eval(text)) as unknown;
+				typeOfResult = typeof result;
+				result = inspect(result);
+			} catch (e) {
+				typeOfResult = typeof e;
+				result = inspect(e);
+			}
+
+			await message.channel.send({
+				embeds: [
+					{
+						title: "Eval",
+						color: config.commandsEmbedsColor,
+						fields: [
+							{
+								name: "Input",
+								value: `\`\`\`js\n${text.slice(0, 2048 - 9)}\`\`\``,
+							},
+							{
+								name: "Output",
+								value: `\`\`\`js\n${result.slice(0, 2048 - 9)}\`\`\``,
+							},
+							{
+								name: "Type",
+								value: `\`\`\`js\n${typeOfResult}\`\`\``,
+							},
+						],
+					},
+				],
+			});
 		} catch (err) {
 			Logger.error(`${(err as Error).name}: ${(err as Error).message}`);
 		}

--- a/src/commands/text/eval.ts
+++ b/src/commands/text/eval.ts
@@ -58,11 +58,11 @@ export const command = new Command(
 						fields: [
 							{
 								name: "Input",
-								value: `\`\`\`js\n${text.slice(0, 2048 - 9)}\`\`\``,
+								value: `\`\`\`js\n${text.slice(0, 1024 - 9)}\`\`\``,
 							},
 							{
 								name: "Output",
-								value: `\`\`\`js\n${result.slice(0, 2048 - 9)}\`\`\``,
+								value: `\`\`\`js\n${result.slice(0, 1024 - 9)}\`\`\``,
 							},
 							{
 								name: "Type",


### PR DESCRIPTION
_I absolutely didn't forget to commit to a new branch_

Improve the eval command!

- Too many useless if-else deleted
- Custom inspect function implemented. It defaults to `util.inspect()` only if the result is an object
- Use prettier to format the input! (moved prettier to prod dependencies and installed `@types/prettier` for typing as dev dependency)
- Removed lots of random "Eval" everywhere
- Tested it locally and it works perfectly:
![image](https://user-images.githubusercontent.com/73136330/149659681-e784534b-7999-4d86-b0b4-efb62add6337.png)
![image](https://user-images.githubusercontent.com/73136330/149659568-0ce91295-6893-465c-b24b-5d264f053f32.png)